### PR TITLE
Add gitpod.io

### DIFF
--- a/Assignment-I
+++ b/Assignment-I
@@ -18,7 +18,7 @@ git log --oneline         => View all commits
 git push                  => Push local commits to remote repository
 =================
 
-1: Clone the below Git repository. 
+1: Clone the below Git repository OR Open the link https://gitpod.io/#/https://github.com/winsonliwh/myzoo
       https://github.com/winsonliwh/myzoo.git
 2). Create a new file "meal-regimens.txt"  with the below content.
 


### PR DESCRIPTION
If developer open this repo by gitpod.io such as https://gitpod.io/#/https://github.com/winsonliwh/myzoo
The browser will open the web page which is the IDE like Visual Studio Code as called Gitpod Code.
In this case, developer don't need to do clone while Gitpod Code do that already.